### PR TITLE
Rename menu item and settings search path to `ApplySyntax`

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,17 +12,17 @@
                 "children":
                 [
                     {
-                        "caption": "DetectSyntax",
+                        "caption": "ApplySyntax",
                         "children":
                         [
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/DetectSyntax/DetectSyntax.sublime-settings"},
+                                "args": {"file": "${packages}/ApplySyntax/ApplySyntax.sublime-settings"},
                                 "caption": "Settings – Default"
                             },
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/User/DetectSyntax.sublime-settings"},
+                                "args": {"file": "${packages}/User/ApplySyntax.sublime-settings"},
                                 "caption": "Settings – User"
                             }
                         ]


### PR DESCRIPTION
Not sure if you want this but I just spent 10 minutes trying to figure out why my settings file wasn't picked up.
