### PR TITLE
Fix function_matches to see "Packages/User" directory

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -48,6 +48,7 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         self.syntaxes = []
         self.plugin_name = 'ApplySyntax'
         self.plugin_dir = os.path.join(sublime.packages_path(), self.plugin_name)
+        self.user_dir = os.path.join(sublime.packages_path(), 'User')
         self.settings_file = self.plugin_name + '.sublime-settings'
         self.reraise_exceptions = False
 
@@ -195,7 +196,14 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
             path_to_file = function_name + '.py'
 
         if re.match(r"^Packages(?:\\|/)", path_to_file) is None:
-            path_to_file = os.path.join(self.plugin_dir, path_to_file)
+            file_in_user_dir = os.path.join(self.user_dir, path_to_file)
+            file_in_plugin_dir = os.path.join(self.plugin_dir, path_to_file)
+            if os.path.exists(file_in_user_dir):
+                path_to_file = file_in_user_dir
+            elif os.path.exists(file_in_plugin_dir):
+                path_to_file = file_in_plugin_dir
+            else:
+                path_to_file = None
         else:
             path_to_file = os.path.join(os.path.dirname(sublime.packages_path), path_to_file)
         function = self.get_function(path_to_file, function_name)


### PR DESCRIPTION
I'm using ST2.

When I put foo.py in my "Packages/User" directory, the function defined in the file is not be called.

This is my `Packages/User/ApplySyntax.sublime-settings`

```
{
    // If you want exceptions reraised so you can see them in the console, change this to true.
    "reraise_exceptions": false,

    // If you want to have a syntax applied when new files are created, set new_file_syntax to the name of the syntax to use.
    // The format is exactly the same as "name" in the rules below. For example, if you want to have a new file use
    // JavaScript syntax, set new_file_syntax to 'JavaScript'.
    "new_file_syntax": false,

    // Put your custom syntax rules here:
    "syntaxes": [
    {
      "name": "RubyMotion",
      "rules": [
        {"function": {"name": "is_rubymotion_file"}}
      ]
    }
    ]
}
```

and `Packages/User/is_rubymotion_file.py`

```
import os.path
import re


def is_rubymotion_file(file_name):
    path = os.path.dirname(file_name)
    file_name = os.path.basename(file_name).lower()
    name, extension = os.path.splitext(file_name)

    result = False
    re_rubymotion = re.compile("Motion::Project::App")

    while path != "/":
        rakefile = os.path.join(path, "Rakefile")
        if os.path.exists(rakefile):
            for line in open(rakefile):
                if re_rubymotion.search(line):
                    result = True
                    break
        path = os.path.dirname(path)

    return extension == ".rb" and result

```
