### PR TITLE
Fixing ST3 compatibility

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -118,10 +118,10 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         # only set the syntax if it's different
         if new_syntax != current_syntax:
             # let's make sure it exists first!
-            if os.path.exists(file_path):
+            try:
                 self.view.set_syntax_file(new_syntax)
                 log('Syntax set to ' + name + ' using ' + new_syntax)
-            else:
+            except:
                 log('Syntax file for ' + name + ' does not exist at ' + new_syntax)
 
     def load_syntaxes(self):


### PR DESCRIPTION
`os.path.exists()` cannot be used to check whether a syntax file exists because of how the files are stored in ST3 (in `.sublime-package` files). Instead, use a `try` and `except` clause and let the function fail if the file does not exist (it will load it from the package file properly).

Tested on ST3 on MacOS.
