### PR TITLE
Attempted fix for #26; .tmLanguage file stored in non-standard location; package name differs from syntax .tmLanguage name

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -106,6 +106,12 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         file_name = name + '.tmLanguage'
         new_syntax = sublime_format_path('/'.join(['Packages', path, file_name]))
 
+        # Some packages store the .tmLanguage at /Syntaxes instead of in the package root path
+        try:
+            sublime.load_resource(new_syntax)
+        except:
+            new_syntax = sublime_format_path('/'.join(['Packages', path, 'Syntaxes', file_name]))
+
         current_syntax = self.view.settings().get('syntax')
 
         # only set the syntax if it's different


### PR DESCRIPTION
Attempted fix for #26, as I discovered that the following packages (which I use) were storing the `.tmLanguage` file in `/Syntaxes` instead of in their package's root directory:
- [Sass](https://github.com/nathos/sass-textmate-bundle)
- [SCSS](https://github.com/MarioRicalde/SCSS.tmbundle)
- [Slim](https://github.com/slim-template/ruby-slim.tmbundle)

Here's what I did:
- Added "package_name" to `set_syntax` method to help account for situations where package name differs from syntax name
- Attempted to account for situations where `.tmLanguage` is stored in `/Syntaxes` instead of root directory by trying `sublime.load_resource(new_syntax)` then handling the exception by setting `new_syntax` to a path with `/Syntaxes`.

I'm not entirely sure if these changes are appropriate (especially the second one!) as I'm not really a Python developer, so please let me know if I should be making any changes.
