### PR TITLE
Added default syntax for Emblem

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -69,9 +69,6 @@
             ]
         },
         {
-            "name": 
-        },
-        {
             // This rule could be incorporated into the next one, but I prefer to be more explicit rather than less
             "name": "Rails/Ruby Haml",
             "rules": [


### PR DESCRIPTION
Emblem (http://emblemjs.com/) is very similar to Slim to the Ruby Slim syntax highlighting so use it for Emblem.
