### PR TITLE
Update ApplySyntax.sublime-settings with Cocoapods rules

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -113,6 +113,8 @@
                 {"file_name": ".*\\.simplecov$"},
                 {"file_name": ".*\\.jbuilder$"},
                 {"file_name": ".*\\.rb$"},
+                {"file_name": ".*\\Podfile$"},
+                {"file_name": ".*\\.podspec$"},
                 // a binary rule does the same thing as a first_line rule that uses a regexp to match a shebang, the
                 // difference being DetectSyntax will construct the regexp and the user doesn't have to. So
                 //


### PR DESCRIPTION
Cocoapods files treat as Ruby files
