### PR TITLE
Invoke syntax detection on an activation event.

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -80,6 +80,9 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
             self.view = view
             self.set_syntax(name)
 
+    def on_activated(self, view):
+        self.detect_syntax(view)
+
     def on_load(self, view):
         self.detect_syntax(view)
 


### PR DESCRIPTION
Due to [this maddening bug](https://github.com/SublimeText/Issues/issues/27) I invoke sublime from the command line with [this wrapper](https://github.com/paulp/homebrew-extras/blob/master/bin/subl). As a consequence, it seems that the event which kicks for a newly opened file is an "activation" event and not a "load" event. ApplySyntax doesn't have a hook for an activation event, so this leaves my newly opened files in a uniform dull grey rather than nicely colored, until some other event kicks, e.g. after I write to the file once - which of course may never happen.
