### PR TITLE
Issue #60 - Add alternate JavaScript/JSON filenames (jshintrc, jscsrc, csslintrc)

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -267,6 +267,12 @@
                 {"file_name": ".*\\.(py|pyw|py3)"},
                 {"binary": "python"}
             ]
+        },
+        {
+            "name": "JavaScript/JSON",
+            "rules": [
+                {"file_name": "^.*(\\.jshintrc|\\.jscsrc|\\.csslintrc)$"}
+            ]
         }
     ]
 }


### PR DESCRIPTION
- JSHint: [.jshintrc](https://github.com/jshint/jshint)
- node-jscs: [.jscsrc](https://github.com/mdevils/node-jscs)
- CSSLint [.csslintrc](https://github.com/gruntjs/grunt-contrib-csslint)

Fixes #60
