### PR TITLE
Add `Cheffile` to the Ruby type

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -132,6 +132,7 @@
                 {"file_name": ".*(\\\\|/)Guardfile$"},
                 {"file_name": ".*(\\\\|/)[Rr]akefile$"},
                 {"file_name": ".*(\\\\|/)Berksfile$"},
+                {"file_name": ".*(\\\\|/)[Cc]heffile$"},
                 {"file_name": ".*(\\\\|/)Thorfile$"},
                 {"file_name": ".*(\\\\|/)Podfile$"},
                 {"file_name": ".*(\\\\|/)config.ru$"},


### PR DESCRIPTION
librarian-chef says it's [rubyish](https://github.com/applicationsonline/librarian-chef/blob/603de858cef9e4e4a25f5013f28d43e218b942b7/lib/librarian/chef/templates/Cheffile#L1-L2).