### PR TITLE
Clarified pattern-matching behaviour of file_name rules

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,15 +100,15 @@ In this case, there is no `match` key, so only one rule needs to match:
 ## Rules
 `rules` is an array of rules that can be used to target specific files with your defined syntax file.  The rules are processed until the first rule matches, so order your rules in a way that makes sense to you.
 
-### Filename Rule
-Filename rule defines a filename with regex.  The pattern is matched against the beginning of the full file path (there is an implicit `^`).
+### File Name Rule
+A `file_name` rule defines a regex to match against the complete file path. The pattern is always anchored to the beginning of the path, as if there were an implicit `^` — so the pattern `/a/b/c` will match the file `/a/b/c/foo.py`, but not the file `/x/y/z/a/b/c/foo.py`. (You may include an explicit `^` at the beginning of the pattern, as some of the default rules do — but the result is the same either way.)
 
 ```js
 {"file_name": ".*\\.xml(\\.dist)?$"},
 ```
 
 ### First Line Rule
-First line rule allows you to check if the first line of the files content matches a given regex. The pattern is matched against the beginning of the line (there is an implicit `^`).
+A `first_line` rule allows you to check whether the first line of the file's content matches a given regex. As with `file_name` rules (see above), the pattern is always anchored to the beginning of the line.
 
 ```js
 {"first_line": "^<\\?xml"},

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,7 +101,7 @@ In this case, there is no `match` key, so only one rule needs to match:
 `rules` is an array of rules that can be used to target specific files with your defined syntax file.  The rules are processed until the first rule matches, so order your rules in a way that makes sense to you.
 
 ### Filename Rule
-Filename rule defines a filename with regex.  This uses the full file path.
+Filename rule defines a filename with regex.  The pattern is matched against the beginning of the full file path (there is an implicit `^`).
 
 ```js
 {"file_name": ".*\\.xml(\\.dist)?$"},

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,7 +108,7 @@ Filename rule defines a filename with regex.  The pattern is matched against the
 ```
 
 ### First Line Rule
-First line rule allows you to check if the first line of the files content matches a given regex.
+First line rule allows you to check if the first line of the files content matches a given regex. The pattern is matched against the beginning of the line (there is an implicit `^`).
 
 ```js
 {"first_line": "^<\\?xml"},


### PR DESCRIPTION
I started using ApplySyntax today and i found myself briefly confused by the behaviour of the `file_name` rule — its pattern is anchored to the beginning of the path, which is not what i initially expected. Looking at some of the default rules and then double-checking the source gave me the explanation i needed, but i thought i could save the next person a few minutes by just noting it in the documentation.