### PR TITLE
Deprecate file_name in favour of file_path

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -275,6 +275,7 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         self.syntaxes = []
         self.reraise_exceptions = False
         self.seen_deprecation_warnings = {
+            'binary': False,
             'file_name': False,
         }
 
@@ -504,7 +505,14 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
                 self.fetch_first_line()
             subject = self.first_line
             regexp = rule.get("first_line")
+        elif "interpreter" in rule:
+            if self.first_line is None:
+                self.fetch_first_line()
+            subject = self.first_line
+            regexp = '^#\\!(?:.+)' + rule.get("interpreter")
         elif "binary" in rule:
+            # Deprecated in favour of `interpreter`
+            self.print_deprecation_warning('binary')
             if self.first_line is None:
                 self.fetch_first_line()
             subject = self.first_line
@@ -513,6 +521,7 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
             subject = self.file_name
             regexp = rule.get("file_path")
         elif "file_name" in rule:
+            # Deprecated in favour of `file_path`
             self.print_deprecation_warning('file_name')
             subject = self.file_name
             regexp = rule.get("file_name")

--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -274,7 +274,21 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         self.view = None
         self.syntaxes = []
         self.reraise_exceptions = False
+        self.seen_deprecation_warnings = {
+            'file_name': False,
+        }
+
         on_touched_callback = self.on_touched
+
+    def print_deprecation_warning(self, keyword):
+        if self.seen_deprecation_warnings[keyword]:
+            return
+
+        self.seen_deprecation_warnings[keyword] = True
+        log(
+            "Warning: '%s' keyword is deprecated and may be removed in the future."
+            % keyword
+        )
 
     def touch(self, view):
         view.settings().set("apply_syntax_touched", True)
@@ -495,7 +509,11 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
                 self.fetch_first_line()
             subject = self.first_line
             regexp = '^#\\!(?:.+)' + rule.get("binary")
+        elif "file_path" in rule:
+            subject = self.file_name
+            regexp = rule.get("file_path")
         elif "file_name" in rule:
+            self.print_deprecation_warning('file_name')
             subject = self.file_name
             regexp = rule.get("file_name")
         elif "contains" in rule:

--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -24,10 +24,10 @@
             "syntax": "XML/XML",
             "extensions": ["xml.dist"],
             "rules": [
-                {"file_name": ".*\\.xml(\\.dist)?$"},
+                {"file_path": ".*\\.xml(\\.dist)?$"},
                 {"first_line": "^<\\?xml"}
                 // See "add_exts_to_lang_settings" setting above for more info
-                // if using extensions, you don't need to set "file_name".
+                // if using extensions, you don't need to set "file_path".
                 // Rule could be simplified to this:
                 //
                 // "syntax": "XML/XML",
@@ -43,7 +43,7 @@
             // in .rb and will be identified as Rails or Ruby otherwise.
             "syntax": "Cucumber/Cucumber Steps",
             "rules": [
-                {"file_name": ".*steps\\.rb$"}
+                {"file_path": ".*steps\\.rb$"}
             ]
         },
         {
@@ -55,16 +55,16 @@
                 "Better RSpec/Better RSpec"
             ],
             "rules": [
-                {"file_name": ".*spec\\.rb$"},
-                {"file_name": ".*/spec/.*\\.rb$"},
-                {"file_name": ".*\\\\spec\\\\.*\\.rb$"}
+                {"file_path": ".*spec\\.rb$"},
+                {"file_path": ".*/spec/.*\\.rb$"},
+                {"file_path": ".*\\\\spec\\\\.*\\.rb$"}
             ]
         },
         {
             // Seems must other will make .html.erb as HTML files
             "syntax": "Rails/HTML (Rails)",
             "rules": [
-                {"file_name": ".*\\.html\\.erb$"}
+                {"file_path": ".*\\.html\\.erb$"}
             ]
         },
         {
@@ -73,7 +73,7 @@
             "syntax": "Rails/Ruby Haml",
             "extensions": ["haml"],
             "rules": [
-                {"file_name": ".*\\.haml$"}
+                {"file_path": ".*\\.haml$"}
             ]
         },
         {
@@ -90,24 +90,24 @@
             "syntax": "Ruby/Ruby",
             "extensions": ["thor", "rake", "simplecov", "jbuilder", "rb", "podspec", "rabl"],
             "rules": [
-                {"file_name": ".*(\\\\|/)Gemfile$"},
-                {"file_name": ".*(\\\\|/)Capfile$"},
-                {"file_name": ".*(\\\\|/)Guardfile$"},
-                {"file_name": ".*(\\\\|/)[Rr]akefile$"},
-                {"file_name": ".*(\\\\|/)Berksfile$"},
-                {"file_name": ".*(\\\\|/)[Cc]heffile$"},
-                {"file_name": ".*(\\\\|/)Thorfile$"},
-                {"file_name": ".*(\\\\|/)Podfile$"},
-                {"file_name": ".*(\\\\|/)config.ru$"},
-                {"file_name": ".*\\\\Vagrantfile(\\\\..*)?$"},
-                {"file_name": ".*/Vagrantfile(/..*)?$"},
-                {"file_name": ".*\\.thor$"},
-                {"file_name": ".*\\.rake$"},
-                {"file_name": ".*\\.simplecov$"},
-                {"file_name": ".*\\.jbuilder$"},
-                {"file_name": ".*\\.rb$"},
-                {"file_name": ".*\\.podspec$"},
-                {"file_name": ".*\\.rabl$"},
+                {"file_path": ".*(\\\\|/)Gemfile$"},
+                {"file_path": ".*(\\\\|/)Capfile$"},
+                {"file_path": ".*(\\\\|/)Guardfile$"},
+                {"file_path": ".*(\\\\|/)[Rr]akefile$"},
+                {"file_path": ".*(\\\\|/)Berksfile$"},
+                {"file_path": ".*(\\\\|/)[Cc]heffile$"},
+                {"file_path": ".*(\\\\|/)Thorfile$"},
+                {"file_path": ".*(\\\\|/)Podfile$"},
+                {"file_path": ".*(\\\\|/)config.ru$"},
+                {"file_path": ".*\\\\Vagrantfile(\\\\..*)?$"},
+                {"file_path": ".*/Vagrantfile(/..*)?$"},
+                {"file_path": ".*\\.thor$"},
+                {"file_path": ".*\\.rake$"},
+                {"file_path": ".*\\.simplecov$"},
+                {"file_path": ".*\\.jbuilder$"},
+                {"file_path": ".*\\.rb$"},
+                {"file_path": ".*\\.podspec$"},
+                {"file_path": ".*\\.rabl$"},
                 // A binary rule does the same thing as a "first_line" rule that uses
                 // a regexp to match a shebang, the difference being ApplySyntax
                 // will construct the regexp and the user doesn't have to. So
@@ -131,7 +131,7 @@
         //     "match": "all",
         //     "rules": [
         //         {"binary": "ruby"},
-        //         {"file_name": ".*\\.ruby$"}
+        //         {"file_path": ".*\\.ruby$"}
         //     ]
         // },
         // {
@@ -154,7 +154,7 @@
         //     "syntax": "Handlebars/Handlebars",
         //     "match": "all",
         //     "rules": [
-        //         {"file_name": ".*\\.html$"},
+        //         {"file_path": ".*\\.html$"},
         //         {"contains": "<script [^>]*type=\"text\\/x-handlebars\"[^>]*>"}
         //     ]
         // },
@@ -163,21 +163,21 @@
             "syntax": "Ruby Slim/Syntaxes/Ruby Slim",
             "extensions": ["emblem"],
             "rules": [
-                {"file_name": ".*\\.emblem$"}
+                {"file_path": ".*\\.emblem$"}
             ]
         },
         {
             "syntax": "Blade/Blade",
             "extensions": ["blade.php"],
             "rules": [
-                {"file_name": ".*\\.blade.php$"}
+                {"file_path": ".*\\.blade.php$"}
             ]
         },
         {
             "syntax": "PHP/PHP",
             "extensions": ["php3", "php4", "php5", "inc", "phtml"],
             "rules": [
-                {"file_name": ".*\\.(php(3|4|5)?|inc|phtml)$"},
+                {"file_path": ".*\\.(php(3|4|5)?|inc|phtml)$"},
                 {"first_line": "^<\\?php"}
             ]
         },
@@ -185,15 +185,15 @@
             "syntax": "PHP/Smarty",
             "extensions": ["tpl"],
             "rules": [
-                {"file_name": ".*\\.tpl$"}
+                {"file_path": ".*\\.tpl$"}
             ]
         },
         {
             "syntax": "YAML/YAML",
             "extensions": [".gemrc", "yml", "yml.dist"],
             "rules": [
-                {"file_name": ".*\\.gemrc$"},
-                {"file_name": ".*\\.yml(\\.dist)?$"}
+                {"file_path": ".*\\.gemrc$"},
+                {"file_path": ".*\\.yml(\\.dist)?$"}
             ]
         },
         {
@@ -202,21 +202,21 @@
             "syntax": "INI/INI",
             "extensions": [".gitattributes", ".gitconfig", ".gitignore", "ini.dist", ".npmrc"],
             "rules": [
-                {"file_name": ".*/git/(attributes|config|ignore)$"},
-                {"file_name": ".*\\\\git\\\\(attributes|config|ignore)$"},
-                {"file_name": ".*\\.(gitattributes|gitconfig|gitignore)$"},
-                {"file_name": ".*\\.ini(\\.dist)?$"},
-                {"file_name": ".*\\.npmrc$"}
+                {"file_path": ".*/git/(attributes|config|ignore)$"},
+                {"file_path": ".*\\\\git\\\\(attributes|config|ignore)$"},
+                {"file_path": ".*\\.(gitattributes|gitconfig|gitignore)$"},
+                {"file_path": ".*\\.ini(\\.dist)?$"},
+                {"file_path": ".*\\.npmrc$"}
             ]
         },
         {
             "syntax": "ShellScript/Shell-Unix-Generic",
             "extensions": ["bash", "sh", "zsh"],
             "rules": [
-                {"file_name": "profile"},
-                {"file_name": ".*\\.bash.*$"},
-                {"file_name": ".*\\.z(shrc|shenv|profile|login|logout).*$"},
-                {"file_name": ".*\\.(bash|sh|zsh)$"},
+                {"file_path": "profile"},
+                {"file_path": ".*\\.bash.*$"},
+                {"file_path": ".*\\.z(shrc|shenv|profile|login|logout).*$"},
+                {"file_path": ".*\\.(bash|sh|zsh)$"},
                 {"binary": "bash"},
                 {"binary": "zsh"}
             ]
@@ -226,7 +226,7 @@
             // Apache files correctly, but I leave it for instructional value
             "syntax": "Apache/Apache",
             "rules": [
-                {"file_name": "^.*(\\.htaccess|\\.htgroups|\\.htpasswd|httpd\\.conf)$"}
+                {"file_path": "^.*(\\.htaccess|\\.htgroups|\\.htpasswd|httpd\\.conf)$"}
             ]
         },
         {
@@ -235,14 +235,14 @@
             "syntax": "Python/Python",
             "extensions": ["py3", "pyw"],
             "rules": [
-                {"file_name": ".*\\.(py|pyw|py3)"},
+                {"file_path": ".*\\.(py|pyw|py3)"},
                 {"binary": "python"}
             ]
         },
         {
             "syntax": "JavaScript/JSON",
             "rules": [
-                {"file_name": "^.*(\\.jshintrc|\\.jscsrc|\\.csslintrc)$"}
+                {"file_path": "^.*(\\.jshintrc|\\.jscsrc|\\.csslintrc)$"}
             ]
         }
     ]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ So in this case, all the rules must match for the syntax to be applied:
      "syntax": "Handlebars/Handlebars",
      "match": "all",
      "rules": [
-         {"file_name": ".*\\.html$"},
+         {"file_path": ".*\\.html$"},
          {"contains": "<script [^>]*type=\"text\\/x-handlebars\"[^>]*>"}
      ]
 ```
@@ -76,24 +76,24 @@ In this case, there is no `match` key, so only one rule needs to match:
         "syntax": "Ruby/Ruby",
         "extensions": ["thor", "rake", "simplecov", "jbuilder", "rb", "podspec", "rabl"],
         "rules": [
-            {"file_name": ".*(\\\\|/)Gemfile$"},
-            {"file_name": ".*(\\\\|/)Capfile$"},
-            {"file_name": ".*(\\\\|/)Guardfile$"},
-            {"file_name": ".*(\\\\|/)[Rr]akefile$"},
-            {"file_name": ".*(\\\\|/)Berksfile$"},
-            {"file_name": ".*(\\\\|/)[Cc]heffile$"},
-            {"file_name": ".*(\\\\|/)Thorfile$"},
-            {"file_name": ".*(\\\\|/)Podfile$"},
-            {"file_name": ".*(\\\\|/)config.ru$"},
-            {"file_name": ".*\\\\Vagrantfile(\\\\..*)?$"},
-            {"file_name": ".*/Vagrantfile(/..*)?$"},
-            {"file_name": ".*\\.thor$"},
-            {"file_name": ".*\\.rake$"},
-            {"file_name": ".*\\.simplecov$"},
-            {"file_name": ".*\\.jbuilder$"},
-            {"file_name": ".*\\.rb$"},
-            {"file_name": ".*\\.podspec$"},
-            {"file_name": ".*\\.rabl$"},
+            {"file_path": ".*(\\\\|/)Gemfile$"},
+            {"file_path": ".*(\\\\|/)Capfile$"},
+            {"file_path": ".*(\\\\|/)Guardfile$"},
+            {"file_path": ".*(\\\\|/)[Rr]akefile$"},
+            {"file_path": ".*(\\\\|/)Berksfile$"},
+            {"file_path": ".*(\\\\|/)[Cc]heffile$"},
+            {"file_path": ".*(\\\\|/)Thorfile$"},
+            {"file_path": ".*(\\\\|/)Podfile$"},
+            {"file_path": ".*(\\\\|/)config.ru$"},
+            {"file_path": ".*\\\\Vagrantfile(\\\\..*)?$"},
+            {"file_path": ".*/Vagrantfile(/..*)?$"},
+            {"file_path": ".*\\.thor$"},
+            {"file_path": ".*\\.rake$"},
+            {"file_path": ".*\\.simplecov$"},
+            {"file_path": ".*\\.jbuilder$"},
+            {"file_path": ".*\\.rb$"},
+            {"file_path": ".*\\.podspec$"},
+            {"file_path": ".*\\.rabl$"},
             {"binary": "ruby"}
         ]
     },
@@ -102,15 +102,17 @@ In this case, there is no `match` key, so only one rule needs to match:
 ## Rules
 `rules` is an array of rules that can be used to target specific files with your defined syntax file.  The rules are processed until the first rule matches, so order your rules in a way that makes sense to you.
 
-### File Name Rule
-A `file_name` rule defines a regex to match against the complete file path. The pattern is always anchored to the beginning of the path, as if there were an implicit `^` — so the pattern `/a/b/c` will match the file `/a/b/c/foo.py`, but not the file `/x/y/z/a/b/c/foo.py`. (You may include an explicit `^` at the beginning of the pattern, as some of the default rules do — but the result is the same either way.)
+### File Path Rule
+A `file_path` rule defines a regex to match against the complete file path. The pattern is always anchored to the beginning of the path, as if there were an implicit `^` — so the pattern `/a/b/c` will match the file `/a/b/c/foo.py`, but not the file `/x/y/z/a/b/c/foo.py`. (You may include an explicit `^` at the beginning of the pattern, as some of the default rules do — but the result is the same either way.)
+
+For backwards compatibility with older versions of ApplySyntax, the rule name `file_name` is also accepted, and functions exactly like `file_path`.
 
 ```js
-{"file_name": ".*\\.xml(\\.dist)?$"},
+{"file_path": ".*\\.xml(\\.dist)?$"},
 ```
 
 ### First Line Rule
-A `first_line` rule allows you to check whether the first line of the file's content matches a given regex. As with `file_name` [rules](#file-name-rule), the pattern is always anchored to the beginning of the line.
+A `first_line` rule allows you to check whether the first line of the file's content matches a given regex. As with `file_path` [rules](#file-path-rule), the pattern is always anchored to the beginning of the line.
 
 ```js
 {"first_line": "^<\\?xml"},
@@ -165,7 +167,7 @@ There is one difference between project specific rules and global rules.  In pro
         {
             "syntax": "XML/XML",
             "rules": [
-                {"file_name": ".*\\.xml(\\.dist)?$"},
+                {"file_path": ".*\\.xml(\\.dist)?$"},
                 {"first_line": "^<\\?xml"}
             ]
         }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,7 +94,7 @@ In this case, there is no `match` key, so only one rule needs to match:
             {"file_path": ".*\\.rb$"},
             {"file_path": ".*\\.podspec$"},
             {"file_path": ".*\\.rabl$"},
-            {"binary": "ruby"}
+            {"interpreter": "ruby"}
         ]
     },
 ```
@@ -118,8 +118,8 @@ A `first_line` rule allows you to check whether the first line of the file's con
 {"first_line": "^<\\?xml"},
 ```
 
-### Binary (Shebang)
-A `binary` rule does the same thing as a `first_line` rule that uses a regex to match a shebang.  The difference being that ApplySyntax will construct the regex for you.
+### Interpreter (Shebang)
+An `interpreter` rule does the same thing as a `first_line` rule that uses a regex to match an interpreter directive (shebang).  The difference being that ApplySyntax will construct the regex for you.
 
 So a `first_line` rule:
 
@@ -130,8 +130,10 @@ So a `first_line` rule:
 Can be simplified as:
 
 ```js
-{"binary": "ruby"}
+{"interpreter": "ruby"}
 ```
+
+For backwards compatibility with older versions of ApplySyntax, the rule name `binary` is also accepted, and functions exactly like `interpreter`.
 
 ### Function Rule
 This is an example of using a custom function to decide whether or not to apply a syntax. The source file should be in a plugin folder. `name` is the function name and `source` is the file in which the function is contained; you must include the package it resides in, all sub-folders leading to the file, and the actual file name (extension not needed as it is assumed to be a python file).


### PR DESCRIPTION
facelessuser/ApplySyntax#76 — the `file_name` rule is somewhat confusing, in that it actually matches against the entire path of the file, not just the name. (The rule was probably originally named that way because `file_name` is how the Sublime API refers to the edited file path.)

This PR adds a new `file_path` rule which behaves exactly the same way as `file_name`, and deprecates the latter in favour of the former.