### PR TITLE
Add the file_size rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 *.pyc
 site/*
+venv/

--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -565,8 +565,6 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
         """Perform file_size match."""
 
         size_rule = rule.get("file_size")
-        file_size = os.path.getsize(self.file_name)
-
         rule_len = len(size_rule)
         if (rule_len <= 1):
             return False
@@ -579,6 +577,8 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
             size = int(size_rule[1:])
         except ValueError:
             return False
+
+        file_size = os.path.getsize(self.file_name)
 
         if operation == '>' and file_size > size:
             return True

--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -481,6 +481,8 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
 
             if 'function' in rule:
                 result = self.function_matches(rule)
+            elif 'file_size' in rule:
+                result = self.filesize_matches(rule)
             else:
                 result = self.regexp_matches(rule)
 
@@ -558,6 +560,34 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
                 raise
             else:
                 return False
+
+    def filesize_matches(self, rule):
+        """Perform file_size match"""
+
+        size_rule = rule.get("file_size")
+        file_size = os.path.getsize(self.file_name)
+
+        rule_len = len(size_rule)
+        if (rule_len <= 1):
+            return False
+
+        operation = size_rule[0]
+        if operation not in ['>', '<', '=']:
+            return False
+
+        try:
+            size = int(size_rule[1:])
+        except ValueError:
+            return False
+
+        if operation == '>' and file_size > size:
+            return True
+        elif operation == '<' and file_size < size:
+            return True
+        elif operation == '=' and file_size == size:
+            return True
+        else:
+            return False
 
     def regexp_matches(self, rule):
         """Perform regex matches."""

--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -562,7 +562,7 @@ class ApplySyntaxCommand(sublime_plugin.EventListener):
                 return False
 
     def filesize_matches(self, rule):
-        """Perform file_size match"""
+        """Perform file_size match."""
 
         size_rule = rule.get("file_size")
         file_size = os.path.getsize(self.file_name)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,6 +116,17 @@ For backwards compatibility with older versions of ApplySyntax, the rule name `f
 !!! warning "Deprecation"
     The previous name for this key was `file_name` and has been deprecated and will be removed in the future.
 
+#### File Size Rule
+A `file_size` rule allows you to define when a syntax should be applied based on the current file's size. This can be useful for applying a plain text syntax to very large files in order to prevent slowdown.
+
+Each `file_size` rule must start with a `>`, `<`, or `=` character to denote the comparison operation, followed by an integer representing the number of *bytes* to compare against the actual file's size.
+
+For example, this rule would apply to all files over 100 megabytes:
+
+```js
+{"file_size": ">104857600"}
+```
+
 #### First Line Rule
 A `first_line` rule allows you to check whether the first line of the file's content matches a given regex. As with `file_path` [rules](#file-path-rule), the pattern is always anchored to the beginning of the line.
 


### PR DESCRIPTION
I've been working with massive mysql dumps recently, and applying any kind of syntax to them results in a nearly unresponsive UI. It's very fast using the plain text syntax, but I only want plain text applied to massive files... not *every* `.sql` file. Hence:

```
{
    "syntax": "Text/Plain text",
    "rules": [
        {"file_size": ">52428800"}
    ]
}
```

`file_size` must start with a `<` `>` or `=` denoting the comparison operation followed by an integer representing the number of bytes. That's it!