### PR TITLE
Differentiate between MXML (Adobe/Apache Flex) files and "normal" XML files

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -29,10 +29,7 @@
             // have any characteristics that distinguish themselves from XML
             // aside from their file extension
             "syntax": "MXML",
-            "extensions": ["mxml"],
-            "rules": [
-                {"first_line": "^<\\?xml"}
-            ]
+            "extensions": ["mxml"]
         },
         {
             // I put XML next because of files like *.tmLanguage. It is unlikely

--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -24,7 +24,18 @@
 
     "default_syntaxes": [
         {
-            // I put XML first because of files like *.tmLanguage. It is unlikely
+            // The MXML rules come before the generic XML rules because they
+            // need syntax highlighting for the CDATA sections, but they do not
+            // have any characteristics that distinguish themselves from XML
+            // aside from their file extension
+            "syntax": "MXML",
+            "extensions": ["mxml"],
+            "rules": [
+                {"first_line": "^<\\?xml"}
+            ]
+        },
+        {
+            // I put XML next because of files like *.tmLanguage. It is unlikely
             // that this rule will result in a false positive, meaning if it
             // matches, you probably want the XML syntax
             "syntax": "XML/XML",


### PR DESCRIPTION
Tested in user settings but could use more testing in default settings.

Fixes #82.

Comments welcome.