### PR TITLE
Add YAML-tmLanguage extension

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -147,7 +147,7 @@
         },
         {
             "syntax": "YAML/YAML",
-            "extensions": [".gemrc", "yml", "yml.dist"]
+            "extensions": [".gemrc", "yml", "yml.dist", "YAML-tmLanguage"]
         },
         {
             // This rule requires the INI plugin to be installed (via Package Control


### PR DESCRIPTION
This extension use, for example, for [Prolog](https://github.com/alnkpa/sublimeprolog/blob/master/support/Prolog.YAML-tmLanguage) and [Jernl](https://github.com/jasongardnerlv/jernl/blob/master/jernl.YAML-tmLanguage) syntaxes. Sublime Text make `YAML-tmLanguage` files `Plain Text` syntax.

Thanks.