### PR TITLE
updated Package Control URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 </blockquote>
 <p><cite class="quote">&ndash; <a href="https://github.com/phillipkoebbe">phillipkoebbe</a></cite></p>
 <h2 id="installation"><a name="user-content-installation" href="#installation" class="headeranchor-link" aria-hidden="true"><span class="headeranchor"></span></a>Installation</h2>
-<p>The recommended installation method is via Package Control.  Learn more here: <a href="https://sublime.wbond.net/">https://sublime.wbond.net/</a>.</p>
+<p>The recommended installation method is via Package Control.  Learn more here: <a href="https://packagecontrol.io/">https://packagecontrol.io/</a>.</p>
               
             </div>
           </div>


### PR DESCRIPTION
Somehow, an old link to https://sublime.wbond.net was still on the front page. I updated it to packagecontrol.io.