### PR TITLE
Fix Git config directory

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -153,8 +153,8 @@
         {
             "syntax": "Git Formats/Git Config",
             "rules": [
-                {"file_path": ".*/\\.git/config"},
-                {"file_path": ".*\\\\\\.git\\\\config"}
+                {"file_path": ".*/\\.git/config$"},
+                {"file_path": ".*\\\\\\.git\\\\config$"}
             ]
         },
         {

--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -153,8 +153,8 @@
         {
             "syntax": "Git Formats/Git Config",
             "rules": [
-                {"file_path": ".*/git/config$"},
-                {"file_path": ".*\\\\git\\\\config$"}
+                {"file_path": ".*/\\.git/config"},
+                {"file_path": ".*\\\\\\.git\\\\config"}
             ]
         },
         {


### PR DESCRIPTION
Add the missing dot to `.git`. Also assume that other files with the same name pattern match, too (`/.git/config.bkp`, `/.git/config~`, etc.).