### PR TITLE
Remove redundant XML first-line rule

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -32,14 +32,8 @@
             "extensions": ["mxml"]
         },
         {
-            // I put XML next because of files like *.tmLanguage. It is unlikely
-            // that this rule will result in a false positive, meaning if it
-            // matches, you probably want the XML syntax
             "syntax": "XML/XML",
-            "extensions": ["xml.dist"],
-            "rules": [
-                {"first_line": "^<\\?xml"}
-            ]
+            "extensions": ["xml.dist"]
         },
         {
             // The Cucumber and RSpec rules come before Rails and Ruby because they end


### PR DESCRIPTION
This rule was probably very relevant in 2012. It was superseded by [a rule](https://github.com/sublimehq/Packages/blob/3a0cf88a275ba010e654aabe8021e23c4ee9b1bd/XML/XML.sublime-syntax#L11) in the default ST packages in 2015 or earlier.