### PR TITLE
Give priority to user-created rules over defaults

### DIFF
--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -224,7 +224,7 @@ def update_extenstions(lst):
     ext_map = {}
 
     # Walk the entries
-    for entry in SETTINGS.get("default_syntaxes", []) + SETTINGS.get("syntaxes", []):
+    for entry in SETTINGS.get("syntaxes", []) + SETTINGS.get("default_syntaxes", []):
         # Grab the extensions from each relevant rule
         ext = []
         if "extensions" in entry:

--- a/ApplySyntax.py
+++ b/ApplySyntax.py
@@ -224,7 +224,7 @@ def update_extenstions(lst):
     ext_map = {}
 
     # Walk the entries
-    for entry in SETTINGS.get("syntaxes", []) + SETTINGS.get("default_syntaxes", []):
+    for entry in SETTINGS.get("prepend_syntaxes") + SETTINGS.get("default_syntaxes") + SETTINGS.get("syntaxes"):
         # Grab the extensions from each relevant rule
         ext = []
         if "extensions" in entry:

--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -22,6 +22,17 @@
     // (true|false|"verbose")
     "debug": true,
 
+    // Add your own syntax application rules here, to be executed
+    // AFTER the "default_syntaxes" rules.
+    "syntaxes": [],
+
+    // Add your own syntax application rules here, to be executed
+    // BEFORE the "default_syntaxes" rules.
+    "prepend_sytaxes": [],
+
+    // These are the package default syntax rules. If you find
+    // that "default_syntaxes" is intercepting one of your custom
+    // "syntaxes" rules, try moving that rule to "prepend_syntaxes"
     "default_syntaxes": [
         {
             // The MXML rules come before the generic XML rules because they


### PR DESCRIPTION
This way, the main repository doesn't have to change every time someone discovers an exception to the default rules. For example, #82 and #125.