### PR TITLE
Fix Gemfile.lock being detected as Ruby on Rails

### DIFF
--- a/as_plugins/is_rails_file.py
+++ b/as_plugins/is_rails_file.py
@@ -19,9 +19,6 @@ def syntax_test(file_path):
     file_name = os.path.basename(file_path).lower()
     name, extension = os.path.splitext(file_name)
 
-    if name == 'gemfile':
-        return True
-
     result = False
 
     # I doubt this is the most elegant way of identifying a Rails directory structure,


### PR DESCRIPTION
This fixes a minor annoyance with Gemfile files:

* `Gemfile.lock` files are neither Ruby on Rails, nor Ruby files. Because there's no dedicated syntax for lock files, we're better off using plain text syntax.
* `Gemfile` will now be set to plain Ruby by this configuration: https://github.com/facelessuser/ApplySyntax/blob/faf045c71b4178e923ad2c8ab2f6e015e9cfeef3/ApplySyntax.sublime-settings#L90-L93