### PR TITLE
Add support for Carthage including .resolved

### DIFF
--- a/ApplySyntax.sublime-settings
+++ b/ApplySyntax.sublime-settings
@@ -98,6 +98,7 @@
                 {"file_path": ".*/[Cc]heffile$"},
                 {"file_path": ".*/Thorfile$"},
                 {"file_path": ".*/Podfile$"},
+                {"file_path": ".*/(Cartfile|Cartfile.resolved)$"},
                 {"file_path": ".*/config.ru$"},
                 {"file_path": ".*/Vagrantfile(/..*)?$"},
                 // Interpreter is a short hand way of doing:


### PR DESCRIPTION
Hi! Would like to add some defaults

- Carthage is as popular as Cocoapods
- .resolved file looks better as Ruby rather than plain text

please, let me know if it is Ok, or still needs an improvement